### PR TITLE
Add ability to change audio device

### DIFF
--- a/include/Menus/AudioMenu.hpp
+++ b/include/Menus/AudioMenu.hpp
@@ -19,6 +19,7 @@ enum AudioMenuOutAction{
 	AUDIO_MENU_OUTPUT_DEC,
 	AUDIO_MENU_OUTPUT_INC,
 	AUDIO_MENU_RESTART,
+	AUDIO_MENU_NEXT_DEVICE,
 };
 
 class AudioMenu : public OptionSelectionMenu {

--- a/source/Menus/AudioMenu.cpp
+++ b/source/Menus/AudioMenu.cpp
@@ -1,5 +1,7 @@
 #include "AudioMenu.hpp"
 
+#include "SFML/Audio/PlaybackDevice.hpp"
+
 #define NUM_TOTAL_MENU_OPTIONS (sizeof(pollable_options)/sizeof(pollable_options[0]))
 
 struct AudioMenuOptionInfo {
@@ -37,12 +39,19 @@ static const AudioMenuOptionInfo audio_restart_option = {
 .is_inc = false, .dec_str = "", .inc_str = "", .inc_out_action = AUDIO_MENU_NO_ACTION,
 .out_action = AUDIO_MENU_RESTART};
 
+static const AudioMenuOptionInfo audio_next_device_option = {
+.base_name = "Output Device", .false_name = "",
+.is_inc = false, .dec_str = "", .inc_str = "", .inc_out_action = AUDIO_MENU_NO_ACTION,
+.out_action = AUDIO_MENU_NEXT_DEVICE};
+
+
 static const AudioMenuOptionInfo* pollable_options[] = {
 &audio_volume_option,
 &audio_mute_option,
 &audio_max_latency_option,
 &audio_output_type_option,
 &audio_restart_option,
+&audio_next_device_option,
 };
 
 AudioMenu::AudioMenu(bool font_load_success, sf::Font &text_font) : OptionSelectionMenu(){
@@ -134,6 +143,11 @@ void AudioMenu::prepare(float menu_scaling_factor, int view_size_x, int view_siz
 				break;
 			case AUDIO_MENU_MUTE:
 				this->labels[index]->setText(this->setTextOptionBool(real_index, audio_data->get_mute()));
+				break;
+			case AUDIO_MENU_NEXT_DEVICE:
+				if (std::optional<std::string> cur_dev = sf::PlaybackDevice::getDevice()) {
+					this->labels[index]->setText(this->setTextOptionString(real_index, *cur_dev));
+				}
 				break;
 			default:
 				break;

--- a/source/WindowScreen_Menu.cpp
+++ b/source/WindowScreen_Menu.cpp
@@ -1,4 +1,7 @@
+#include <iostream>
+
 #include "frontend.hpp"
+#include "SFML/Audio/PlaybackDevice.hpp"
 
 #define FPS_WINDOW_SIZE 64
 
@@ -1370,6 +1373,25 @@ void WindowScreen::poll(bool do_everything) {
 							break;
 						case AUDIO_MENU_RESTART:
 							this->audio_data->request_audio_restart();
+							break;
+						case AUDIO_MENU_NEXT_DEVICE:
+							if (std::optional<std::string> cur_dev = sf::PlaybackDevice::getDevice()) {
+								std::cout << *cur_dev << std::endl;
+								int idx = 0;
+								auto audio_devices =  sf::PlaybackDevice::getAvailableDevices();
+								for (const std::string& device : audio_devices) {
+									if (device == *cur_dev) {
+										break;
+									}
+									idx++;
+								}
+								idx = std::max((idx + 1) % static_cast<int>(audio_devices.size()), 0);
+								std::cout << "next device: " << audio_devices.at(idx)  << std::endl;
+								if (sf::PlaybackDevice::setDevice(audio_devices.at(idx))) {
+									std::cout << "Device selected: " << audio_devices.at(idx) << std::endl;
+									// this->audio_data->request_audio_restart();
+								}
+							}
 							break;
 						default:
 							break;


### PR DESCRIPTION
Adds a basic button that cycles through the available audio output devices.
This is not complete yet. but is a start for this.
Currently the device is not saved between runs of the application.